### PR TITLE
Fix for bug preventing clicking "Full edit post" in some cases.

### DIFF
--- a/XML/Emerald v1.5.xml
+++ b/XML/Emerald v1.5.xml
@@ -787,6 +787,7 @@ form #message {
 .popup_menu {
 	background: #fff;
 	border: 1px solid #ccc;
+	z-index: 100;
 }
 
 .popup_menu .popup_item {


### PR DESCRIPTION
Sometimes the user can not click the full edit post because the modal is covered by the next post.